### PR TITLE
cmake: forbid in-source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.8)
 project(skeleton C)
 
+if(PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+    message(SEND_ERROR "In-source builds are not allowed. They conflict with PHP's own Makefiles.")
+endif()
+
 add_compile_definitions(HAVE_SKELETON)
 
 set(SOURCE_FILES php_skeleton skeleton.c)


### PR DESCRIPTION
CMake in-source builds will conflict with PHP's autotools-based
Makefiles. Forbidding them avoids confusing the user when things stop
working if they use "cmake ." on the command line.